### PR TITLE
add kubectl exec credential plugin (get-token, import-cluster, import-clusters)

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,25 +31,52 @@ uvx openshift-cluster-login
 
 ## Usage
 
+### Interactive login
+
 ```shell
-ocl
+ocl login
 ```
 
 <img src="demo/quickstart.gif"/>
 
-This spawns a new shell with the following environment variables are set:
+This spawns a new shell with the following environment variables set:
 
 * `KUBECONFIG` - path to kubeconfig file
 * `OCL_CLUSTER_NAME` - cluster name
 * `OCL_CLUSTER_CONSOLE` - url to cluster console
 
+### kubectl exec credential plugin
+
+OCL can act as a [kubectl exec credential plugin](https://kubernetes.io/docs/reference/access-authn-authz/authentication/#client-go-credential-plugins), allowing `kubectl` to transparently fetch and refresh credentials without a separate login step.
+
+**One-time setup:**
+
+```shell
+ocl import-cluster <cluster>
+```
+
+This adds the cluster to `~/.kube/config` and creates a shared `ocl` user entry (if not already present) that all imported contexts reference. After that, any `kubectl` command against the cluster works directly — OCL handles authentication in the background.
+
+To import all clusters at once:
+
+```shell
+ocl import-clusters
+```
+
+**How it works:**
+
+`kubectl` calls `ocl get-token` whenever it needs credentials. OCL reads the cluster's server URL from the `KUBERNETES_EXEC_INFO` environment variable that kubectl sets, looks up the matching cluster, checks its token cache, validates via `oc whoami` if needed, re-authenticates if expired, and returns an `ExecCredential` JSON. Tokens are cached and revalidated at most once every 5 minutes to avoid per-command overhead.
+
+Because all imported contexts share a single `ocl` user entry, running `ocl import-clusters` is a true one-time setup — no per-cluster credential configuration required.
+
 ## Features
 
-OCL currently provides the following features (get help with `-h` or `--help`):
+OCL currently provides the following features (get help with `--help`):
 
 * OpenShift console login (`oc login`) via GitHub or Red Hat authentication
+* kubectl exec credential plugin (`get-token`, `import-cluster`, `import-clusters`)
 * Get cluster and namespace information from app-interface or user-defined (`OCL_USER_CLUSTERS`)
-* Open the OpenShift console in  the browser (`--open-in-browser`)
+* Open the OpenShift console in the browser (`--open-in-browser`)
 * Star your most often used namespaces `Ctrl+S` in the UI
 * Shell completion (`--install-completion`, `--show-completion`)
 * Credentials via environment variables or shell command (e.g., [1password CLI](https://developer.1password.com/docs/cli/))

--- a/demo/quickstart.tape
+++ b/demo/quickstart.tape
@@ -8,7 +8,7 @@ Type "# Let's run ocl in interactive mode"
 Sleep 1s
 Enter
 
-Type "ocl"
+Type "ocl login"
 Sleep 1s
 Enter
 Sleep 3s

--- a/openshift_cluster_login/__main__.py
+++ b/openshift_cluster_login/__main__.py
@@ -386,10 +386,81 @@ def print(msg: str | Text, *, quiet: bool) -> None:  # noqa: A001
     rich_print(msg)
 
 
+def _cluster_in_kubeconfig(cluster_name: str) -> bool:
+    result = subprocess.run(
+        ["kubectl", "config", "get-clusters"],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        return False
+    return cluster_name in result.stdout.strip().splitlines()[1:]
+
+
+def _write_exec_credential_entry(cluster: Cluster) -> None:
+    subprocess.run(
+        ["kubectl", "config", "set-cluster", cluster.name, f"--server={cluster.server_url}"],
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        [
+            "kubectl", "config", "set-credentials", "ocl",
+            "--exec-api-version=client.authentication.k8s.io/v1beta1",
+            "--exec-command=ocl",
+            "--exec-arg=get-token",
+            "--exec-interactive-mode=IfAvailable",
+            "--exec-provide-cluster-info=true",
+        ],
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        [
+            "kubectl", "config", "set-context", cluster.name,
+            f"--cluster={cluster.name}",
+            "--user=ocl",
+        ],
+        check=True,
+        capture_output=True,
+    )
+
+
 def _find_cluster_by_server(server_url: str) -> Cluster | None:
     clusters = clusters_from_app_interface()
     clusters += [Cluster(**c) for c in json.loads(get_var("USER_CLUSTERS", default="[]"))]
     return next((c for c in clusters if c.server_url == server_url), None)
+
+@app.command("import-cluster")
+def import_cluster(
+    cluster_name: str = typer.Argument(..., help="Cluster name", autocompletion=complete_cluster),
+    *,
+    overwrite: bool = typer.Option(default=False, help="Overwrite existing kubeconfig entry."),
+) -> None:
+    """Add a cluster to ~/.kube/config as an exec credential plugin entry."""
+    cluster = select_cluster(cluster_name)
+    if not overwrite and _cluster_in_kubeconfig(cluster.name):
+        rich_print(f"[yellow]warning: skipping {cluster.name}, already exists[/]")
+        return
+    _write_exec_credential_entry(cluster)
+    rich_print(f"imported [bold green]{cluster.name}[/] ({cluster.server_url})")
+
+
+@app.command("import-clusters")
+def import_clusters(
+    *,
+    overwrite: bool = typer.Option(default=False, help="Overwrite existing kubeconfig entries."),
+) -> None:
+    """Add all clusters to ~/.kube/config as exec credential plugin entries."""
+    clusters = clusters_from_app_interface()
+    clusters += [Cluster(**c) for c in json.loads(get_var("USER_CLUSTERS", default="[]"))]
+    for cluster in sorted(clusters, key=lambda c: c.name):
+        if not overwrite and _cluster_in_kubeconfig(cluster.name):
+            rich_print(f"[yellow]warning: skipping {cluster.name}, already exists[/]")
+            continue
+        _write_exec_credential_entry(cluster)
+        rich_print(f"added [bold green]{cluster.name}[/] ({cluster.server_url})")
+
 
 
 @app.command("get-token")

--- a/openshift_cluster_login/__main__.py
+++ b/openshift_cluster_login/__main__.py
@@ -265,6 +265,18 @@ def oc_check_login(cluster: Cluster) -> bool:
         return False
 
 
+def validate_token(cluster: Cluster, token: str) -> bool:
+    try:
+        subprocess.run(
+            ["oc", "whoami", f"--token={token}", f"--server={cluster.server_url}"],
+            check=True,
+            capture_output=True,
+        )
+        return True
+    except subprocess.CalledProcessError:
+        return False
+
+
 def fetch_token(cluster: Cluster, idps: list[str]) -> str:
     hypershift = bool(cluster.spec.hypershift) if cluster.spec else False
     idp = select_idp(cluster.console_url, idps=idps) if not hypershift else None

--- a/openshift_cluster_login/__main__.py
+++ b/openshift_cluster_login/__main__.py
@@ -69,7 +69,7 @@ BANNER = """
              ;cloooolc;              ;clloooolc;         oKXKKKXXKKKKKd'
 """
 
-app = typer.Typer(rich_markup_mode="rich")
+app = typer.Typer(rich_markup_mode="rich", no_args_is_help=True)
 
 
 def get_var(var_name: str, default: Any = None, *, hidden: bool = False) -> str:
@@ -380,8 +380,8 @@ def print(msg: str | Text, *, quiet: bool) -> None:  # noqa: A001
     rich_print(msg)
 
 
-@app.command(epilog="Made with :heart: by [blue]https://github.com/chassing[/]")
-def main(  # noqa: C901
+@app.command("login", epilog="Made with :heart: by [blue]https://github.com/chassing[/]")
+def login(  # noqa: C901
     cluster_name: str = typer.Argument(
         None,
         help="Cluster name",
@@ -416,6 +416,7 @@ def main(  # noqa: C901
         help="Enable last selected namespace history. This will preselect the last used namespace.",
     ),
 ) -> None:
+    """Login to an OpenShift cluster and spawn a new shell with KUBECONFIG set."""
     logging.basicConfig(
         level=logging.INFO if not debug else logging.DEBUG, format="%(message)s"
     )

--- a/openshift_cluster_login/__main__.py
+++ b/openshift_cluster_login/__main__.py
@@ -1,3 +1,4 @@
+import builtins
 import copy
 import hashlib
 import json
@@ -10,6 +11,7 @@ import sys
 import tempfile
 import webbrowser
 from collections.abc import Generator
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
 
@@ -47,6 +49,10 @@ user_config_dir = Path(appdirs.user_config_dir)
 user_config_dir.mkdir(parents=True, exist_ok=True)
 history_file = user_config_dir / "history"
 history_file.touch()
+
+EXEC_CREDENTIAL_TTL = 5 * 60  # seconds; how long kubectl caches the token in-memory
+TOKEN_VALIDATION_TTL = 5 * 60  # seconds; how often to re-validate via oc whoami
+
 star_file = user_config_dir / "star.json"
 
 
@@ -378,6 +384,61 @@ def print(msg: str | Text, *, quiet: bool) -> None:  # noqa: A001
     if quiet:
         return
     rich_print(msg)
+
+
+def _find_cluster_by_server(server_url: str) -> Cluster | None:
+    clusters = clusters_from_app_interface()
+    clusters += [Cluster(**c) for c in json.loads(get_var("USER_CLUSTERS", default="[]"))]
+    return next((c for c in clusters if c.server_url == server_url), None)
+
+
+@app.command("get-token")
+def get_token(
+    cluster_name: str | None = typer.Option(
+        default=None,
+        help="Cluster name. Bypasses KUBERNETES_EXEC_INFO; useful for testing.",
+        autocompletion=complete_cluster,
+    ),
+    idp: list[str] = typer.Option(  # noqa: B008
+        default=["redhat-app-sre-auth"],
+        help="Automatically login via given IDPs (use in given order, try next one if failed).",
+    ),
+) -> None:
+    """Output an ExecCredential for use as a kubectl exec credential plugin."""
+    if cluster_name:
+        cluster = select_cluster(cluster_name)
+    else:
+        exec_info_raw = os.environ.get("KUBERNETES_EXEC_INFO")
+        if not exec_info_raw:
+            typer.echo("KUBERNETES_EXEC_INFO not set — pass --cluster or invoke via kubectl", err=True)
+            raise typer.Exit(1)
+
+        server_url = json.loads(exec_info_raw)["spec"]["cluster"]["server"]
+        cluster = _find_cluster_by_server(server_url)
+        if cluster is None:
+            typer.echo(f"No OCL cluster found for server {server_url}", err=True)
+            raise typer.Exit(1)
+
+    cache_key = f"token:{cluster.name}"
+    validated_key = f"token_validated:{cluster.name}"
+
+    token = cache.get(cache_key)
+    recently_validated = cache.get(validated_key)
+
+    if not token or (not recently_validated and not validate_token(cluster, token)):
+        token = fetch_token(cluster, idps=idp)
+        cache.set(cache_key, token)
+
+    cache.set(validated_key, True, expire=TOKEN_VALIDATION_TTL)
+    expiry = datetime.now(tz=UTC) + timedelta(seconds=EXEC_CREDENTIAL_TTL)
+    builtins.print(json.dumps({
+        "apiVersion": "client.authentication.k8s.io/v1beta1",
+        "kind": "ExecCredential",
+        "status": {
+            "token": token,
+            "expirationTimestamp": expiry.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        },
+    }))
 
 
 @app.command("login", epilog="Made with :heart: by [blue]https://github.com/chassing[/]")

--- a/openshift_cluster_login/__main__.py
+++ b/openshift_cluster_login/__main__.py
@@ -265,6 +265,28 @@ def oc_check_login(cluster: Cluster) -> bool:
         return False
 
 
+def fetch_token(cluster: Cluster, idps: list[str]) -> str:
+    hypershift = bool(cluster.spec.hypershift) if cluster.spec else False
+    idp = select_idp(cluster.console_url, idps=idps) if not hypershift else None
+    if idp or hypershift:
+        with requests.Session() as session:
+            session.auth = HTTPKerberosAuth()
+            r = session.get(
+                token_request_url(cluster.console_url, idp, hypershift=hypershift)
+            )
+            r.raise_for_status()
+            form_data = pq(r.text)("form").serialize_dict()
+            r = session.post(
+                token_display_url(cluster.console_url, hypershift=hypershift),
+                data=form_data,
+            )
+            r.raise_for_status()
+            return pq(r.text)("code")[0].text
+    else:
+        webbrowser.open(cluster.console_url)
+        return Prompt.ask("Enter token", password=True)
+
+
 def oc_setup(cluster: Cluster, idps: list[str], *, refresh_login: bool) -> None:
     with Progress(
         SpinnerColumn(), TextColumn("[progress.description]{task.description}")
@@ -283,33 +305,8 @@ def oc_setup(cluster: Cluster, idps: list[str], *, refresh_login: bool) -> None:
             if not refresh_login and logged_in:
                 return
 
-            hypershift = bool(cluster.spec.hypershift) if cluster.spec else False
-            idp = select_idp(cluster.console_url, idps=idps) if not hypershift else None
-            if idp or hypershift:
-                with requests.Session() as session:
-                    session.auth = HTTPKerberosAuth()
-                    r = session.get(
-                        token_request_url(
-                            cluster.console_url, idp, hypershift=hypershift
-                        )
-                    )
-                    r.raise_for_status()
-                    form_data = pq(r.text)("form").serialize_dict()
-                    r = session.post(
-                        token_display_url(cluster.console_url, hypershift=hypershift),
-                        data=form_data,
-                    )
-                    r.raise_for_status()
-                    token = pq(r.text)("code")[0].text
-            else:
-                webbrowser.open(cluster.console_url)
-                progress.stop()
-                # manual login
-                token = Prompt.ask("Enter token", password=True)
-                progress.start()
-
             task = progress.add_task(description="CLI login ...", total=1)
-            oc_login(cluster=cluster, token=token)
+            oc_login(cluster=cluster, token=fetch_token(cluster, idps=idps))
             progress.remove_task(task)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openshift-cluster-login"
-version = "1.4.2"
+version = "2.0.0"
 description = "Openshift cluster login on command line"
 authors = [{ name = "Christian Assing", email = "chris@ca-net.org" }]
 license = { text = "MIT License" }

--- a/uv.lock
+++ b/uv.lock
@@ -1029,7 +1029,7 @@ wheels = [
 
 [[package]]
 name = "openshift-cluster-login"
-version = "1.4.1"
+version = "2.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "appdirs" },


### PR DESCRIPTION
## Summary

Adds support for OCL as a [kubectl exec credential plugin](https://kubernetes.io/docs/reference/access-authn-authz/authentication/#client-go-credential-plugins), allowing `kubectl`/`oc` to transparently fetch and refresh OpenShift credentials without a separate login step.

### New commands

- `ocl import-cluster <cluster>` — adds a cluster to `~/.kube/config`, using the shared `ocl` user which uses `ocl get-token` as exec credential plugin. All imported contexts share this single user entry, so no per-cluster credential configuration is required.
- `ocl import-clusters` — imports all clusters from app-interface at once.
- `ocl get-token` — exec plugin entrypoint called by `kubectl`/`oc`. Reads the cluster's server URL from the `KUBERNETES_EXEC_INFO` env var that kubectl sets, looks up the matching cluster, checks/validates the cached token, re-authenticates if needed, and returns an `ExecCredential` JSON. Tokens are cached and revalidated at most once every 5 minutes. A `--cluster` option is available to bypass `KUBERNETES_EXEC_INFO` for testing.

### Other changes

- `ocl login` replaces bare `ocl` as the interactive login command.
- Internal refactors: extracted `fetch_token()` and `validate_token()` helpers.

## Breaking changes

- `ocl` without a subcommand now prints help instead of launching the interactive TUI. Replace any invocations of `ocl` with `ocl login`.
- **Version bumped to 2.0.0.**